### PR TITLE
Refactor: create public function for decoding JWT without validating 'azp' and 'iss'

### DIFF
--- a/src/Services/Decoders/RequestBasedJwtTokenDecoder.php
+++ b/src/Services/Decoders/RequestBasedJwtTokenDecoder.php
@@ -25,7 +25,7 @@ readonly class RequestBasedJwtTokenDecoder
             return null;
         }
 
-        return $this->decoder->decodeWithSpecifiedValidation($token, $validateIss, $validateAzp);
+        return $this->decoder->decodeWithSpecifiedValidation($token, $validateAzp, $validateIss);
     }
 
     /**

--- a/src/Services/Decoders/RequestBasedJwtTokenDecoder.php
+++ b/src/Services/Decoders/RequestBasedJwtTokenDecoder.php
@@ -16,11 +16,16 @@ readonly class RequestBasedJwtTokenDecoder
 
     public function getDecodedJwt(): ?stdClass
     {
+        return $this->getDecodedJwtWithSpecifiedValidation(true, true);
+    }
+
+    public function getDecodedJwtWithSpecifiedValidation(bool $validateAzp, bool $validateIss): ?stdClass
+    {
         if (! $token = $this->getToken()) {
             return null;
         }
 
-        return $this->decoder->decode($token);
+        return $this->decoder->decodeWithSpecifiedValidation($token, $validateIss, $validateAzp);
     }
 
     /**

--- a/tests/JwtTokenDecoderTest.php
+++ b/tests/JwtTokenDecoderTest.php
@@ -98,6 +98,48 @@ class JwtTokenDecoderTest extends TestCase
         $decoder->decode($this->token);
     }
 
+    public function test_invalid_azp_without_azp_validation()
+    {
+        $this->buildCustomToken([
+            'custom-claim-key' => 'custom-claim-value',
+            'iss' => 'http://localhost/realms/master',
+            'azp' => 'invalid-azp',
+        ]);
+
+        $decoder = new JwtTokenDecoder(
+            new ConfigRealmJwkRetriever()
+        );
+
+        $decodedToken = $decoder->decodeWithSpecifiedValidation($this->token, false, true);
+
+        $this->assertObjectHasProperty('iss', $decodedToken);
+        $this->assertObjectHasProperty('azp', $decodedToken);
+
+        $this->assertEquals('http://localhost/realms/master', $decodedToken->iss);
+        $this->assertEquals('invalid-azp', $decodedToken->azp);
+    }
+
+    public function test_invalid_issuer_without_iss_validation()
+    {
+        $this->buildCustomToken([
+            'custom-claim-key' => 'custom-claim-value',
+            'iss' => 'http://invalid.issuer',
+            'azp' => 'tolkevarav-web-dev',
+        ]);
+
+        $decoder = new JwtTokenDecoder(
+            new ConfigRealmJwkRetriever()
+        );
+
+        $decodedToken = $decoder->decodeWithSpecifiedValidation($this->token, true, false);
+
+        $this->assertObjectHasProperty('iss', $decodedToken);
+        $this->assertObjectHasProperty('azp', $decodedToken);
+
+        $this->assertEquals('http://invalid.issuer', $decodedToken->iss);
+        $this->assertEquals('tolkevarav-web-dev', $decodedToken->azp);
+    }
+
     public function test_invalid_expiry()
     {
         $this->expectException(InvalidJwtTokenException::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,6 +53,8 @@ class TestCase extends Orchestra
         $this->publicKey = openssl_pkey_get_details($this->privateKey)['key'];
 
         $this->payload = [
+            'azp' => 'tolkevarav-web-dev',
+            'iss' => 'http://localhost/realms/master',
             'tolkevarav' => [
                 'personalIdentityCode' => '3430717934355',
             ],
@@ -76,6 +78,9 @@ class TestCase extends Orchestra
             'realm_public_key' => $this->plainPublicKey(),
             'jwt_payload_custom_claims_attribute' => 'tolkevarav',
             'realm_public_key_retrieval_mode' => 'config',
+            'base_url' => 'http://localhost',
+            'realm' => 'master',
+            'accepted_authorized_parties' => 'tolkevarav-web-dev',
         ]);
     }
 


### PR DESCRIPTION
* For JWT endpoint validation, I needed to decode the JWT without performing the library’s default `azp` validation. I had to make some very minor changes to support this.
* I modified the behaviour with `azp` and `iss` validation so that their validation is not skipped when the environment variables are empty. I hope this isn’t micro-obsessing, but I thought of a scenario of someone having a typo in environment variable – they might not want the validation to be quietly skipped in that case.
