### PR TITLE
#111: Specify exception http status codes

### DIFF
--- a/config/keycloak.php
+++ b/config/keycloak.php
@@ -56,7 +56,7 @@ return [
      * The property from JWT token that contains the user identifier.
      * This will be confronted against `user_provider_credential` attribute, while authenticating.
      */
-    'token_principal_attribute' => env('KEYCLOAK_TOKEN_PRINCIPAL_ATTRIBUTE', 'tolkevarav.personalIdentityCode'),
+    'token_principal_attribute' => env('KEYCLOAK_TOKEN_PRINCIPAL_ATTRIBUTE', 'tolkevarav.personalIdentificationCode'),
 
     /*
      * You can add a leeway to account for when there is a clock skew times between the signing and verifying servers.

--- a/src/Exceptions/InvalidJwtTokenException.php
+++ b/src/Exceptions/InvalidJwtTokenException.php
@@ -3,7 +3,18 @@
 namespace KeycloakAuthGuard\Exceptions;
 
 use Nette\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
-class InvalidJwtTokenException extends InvalidArgumentException
+class InvalidJwtTokenException extends InvalidArgumentException implements HttpExceptionInterface
 {
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_FORBIDDEN;
+    }
+
+    public function getHeaders(): array
+    {
+        return [];
+    }
 }

--- a/src/Exceptions/InvalidJwtTokenPayloadException.php
+++ b/src/Exceptions/InvalidJwtTokenPayloadException.php
@@ -3,7 +3,18 @@
 namespace KeycloakAuthGuard\Exceptions;
 
 use League\Config\Exception\InvalidConfigurationException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
-class InvalidJwtTokenPayloadException extends InvalidConfigurationException
+class InvalidJwtTokenPayloadException extends InvalidConfigurationException implements HttpExceptionInterface
 {
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_UNAUTHORIZED;
+    }
+
+    public function getHeaders(): array
+    {
+        return [];
+    }
 }

--- a/src/Exceptions/UserNotFoundException.php
+++ b/src/Exceptions/UserNotFoundException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace KeycloakAuthGuard\Exceptions;
-
-use RuntimeException;
-
-class UserNotFoundException extends RuntimeException
-{
-}

--- a/src/Models/JwtPayloadUser.php
+++ b/src/Models/JwtPayloadUser.php
@@ -10,7 +10,7 @@ readonly class JwtPayloadUser implements Authenticatable
 {
     public string $id;
 
-    public string $personalIdentityCode;
+    public string $personalIdentificationCode;
 
     public string $institutionUserId;
 
@@ -27,7 +27,7 @@ readonly class JwtPayloadUser implements Authenticatable
     public function __construct(array $jwtPayloadData)
     {
         $this->id = $jwtPayloadData['userId'] ?? '';
-        $this->personalIdentityCode = $jwtPayloadData['personalIdentityCode'] ?? '';
+        $this->personalIdentificationCode = $jwtPayloadData['personalIdentificationCode'] ?? '';
         $this->forename = $jwtPayloadData['forename'] ?? '';
         $this->surname = $jwtPayloadData['surname'] ?? '';
         $this->privileges = $jwtPayloadData['privileges'] ?? [];
@@ -36,7 +36,7 @@ readonly class JwtPayloadUser implements Authenticatable
         $this->institutionId = $jwtPayloadData['selectedInstitution']['id'] ?? '';
         $this->institutionName = $jwtPayloadData['selectedInstitution']['name'] ?? '';
 
-        if (empty($this->id) || empty($this->personalIdentityCode)) {
+        if (empty($this->id) || empty($this->personalIdentificationCode)) {
             throw new InvalidJwtTokenPayloadException('JWT token payload structure not match with configured user model');
         }
     }

--- a/tests/ApiRealmJwkRetrieverTest.php
+++ b/tests/ApiRealmJwkRetrieverTest.php
@@ -32,7 +32,7 @@ class ApiRealmJwkRetrieverTest extends TestCase
 
         $this->buildCustomToken([
             'tolkevarav' => [
-                'personalIdentityCode' => 'some_code',
+                'personalIdentificationCode' => 'some_code',
             ],
         ], $keyId);
         $decodedToken = JWT::decode($this->token, $keySet);

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -70,7 +70,7 @@ class AuthenticateTest extends TestCase
 
         $this->buildCustomToken([
             'tolkevarav' => [
-                'personalIdentityCode' => 'some_code',
+                'personalIdentificationCode' => 'some_code',
             ],
         ]);
 
@@ -81,7 +81,7 @@ class AuthenticateTest extends TestCase
     {
         $this->buildCustomToken([
             'tolkevarav' => [
-                'personalIdentityCode' => '3430717934355',
+                'personalIdentificationCode' => '3430717934355',
                 'privileges' => [
                     'ADD_ROLE',
                 ],
@@ -96,7 +96,7 @@ class AuthenticateTest extends TestCase
     {
         $this->buildCustomToken([
             'tolkevarav' => [
-                'personalIdentityCode' => '3430717934355',
+                'personalIdentificationCode' => '3430717934355',
                 'privileges' => [
                     'access_to_super_secret',
                 ],
@@ -112,7 +112,7 @@ class AuthenticateTest extends TestCase
     {
         $this->buildCustomToken([
             'tolkevarav' => [
-                'personalIdentityCode' => '3430717934355',
+                'personalIdentificationCode' => '3430717934355',
                 'privileges' => [
                     'not_so_secret',
                 ],
@@ -127,7 +127,7 @@ class AuthenticateTest extends TestCase
     {
         $this->buildCustomToken([
             'tolkevarav' => [
-                'personalIdentityCode' => '3430717934355',
+                'personalIdentificationCode' => '3430717934355',
                 'privileges' => [
                     'ADD_ROLE',
                 ],
@@ -157,7 +157,7 @@ class AuthenticateTest extends TestCase
 
         $this->buildCustomToken([
             'tolkevarav' => [
-                'personalIdentityCode' => '3430717934355',
+                'personalIdentificationCode' => '3430717934355',
                 'userId' => '2ad53f6d-b876-4855-ae67-5d29b126c214',
                 'institutionUserId' => 'e1057c3e-661f-4a23-8243-e770cb56bcb8',
                 'forename' => 'Forename',
@@ -185,7 +185,7 @@ class AuthenticateTest extends TestCase
         $this->buildCustomToken([
             'iat' => time() + 30,   // time ahead in the future
             'tolkevarav' => [
-                'personalIdentityCode' => '3430717934355',
+                'personalIdentificationCode' => '3430717934355',
             ],
         ]);
 
@@ -200,7 +200,7 @@ class AuthenticateTest extends TestCase
         $this->buildCustomToken([
             'iat' => time() + 30, // time ahead in the future
             'tolkevarav' => [
-                'personalIdentityCode' => '3430717934355',
+                'personalIdentificationCode' => '3430717934355',
             ],
         ]);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,7 +56,7 @@ class TestCase extends Orchestra
             'azp' => 'tolkevarav-web-dev',
             'iss' => 'http://localhost/realms/master',
             'tolkevarav' => [
-                'personalIdentityCode' => '3430717934355',
+                'personalIdentificationCode' => '3430717934355',
             ],
         ];
 


### PR DESCRIPTION
Towards [#111](https://github.com/keeleinstituut/tv-tolkevarav/issues/111)

* Renamed `personalIdentityCode` to `personalIdentificationCode`. This was a mistake originated by me in `tv-authorization`. It should have always been `personalIdentificationCode`.
* Specified HTTP status codes for exceptions. Example: if personal identification code is missing, 401 status code is now returned. Previously was 500.
* Removed an unused class (`UserNotFoundException`). My apologies if it was left on purpose.

I discovered that if the payload exception is thrown (e.g. personal identification code is missing), server returns 500 HTTP status code. 