### PR TITLE
Fix: Read "keycloak.guzzle_options" config value from environment as JSON

### DIFF
--- a/config/keycloak.php
+++ b/config/keycloak.php
@@ -80,5 +80,5 @@ return [
      * GuzzleHttp Client options
      * @link http://docs.guzzlephp.org/en/stable/request-options.html
      */
-    'guzzle_options' => [],
+    'guzzle_options' => json_decode(env('ACCEPTED_AUTHORIZED_PARTIES', '{}'), true),
 ];

--- a/config/keycloak.php
+++ b/config/keycloak.php
@@ -80,5 +80,5 @@ return [
      * GuzzleHttp Client options
      * @link http://docs.guzzlephp.org/en/stable/request-options.html
      */
-    'guzzle_options' => json_decode(env('ACCEPTED_AUTHORIZED_PARTIES', '{}'), true),
+    'guzzle_options' => json_decode(env('GUZZLE_OPTIONS', '{}'), true),
 ];


### PR DESCRIPTION
I needed to override Guzzle options for local testing. I discovered that the `keycloak.guzzle_options` config value was not being read from environment, which I needed to do for overriding. I thought I might as well introduce the change as a pull request.