### PR TITLE
Fix: ensure JSON is decoded as array in CachedRealmJwkRetriever

### DIFF
--- a/src/Services/CachedRealmJwkRetriever.php
+++ b/src/Services/CachedRealmJwkRetriever.php
@@ -25,7 +25,7 @@ class CachedRealmJwkRetriever implements RealmJwkRetrieverInterface
         if ($this->repository->has($this->getCacheKey($kid))) {
             $jwks = $this->repository->get($this->getCacheKey($kid));
 
-            return JWK::parseKeySet(json_decode($jwks));
+            return JWK::parseKeySet(json_decode($jwks, true));
         }
 
         $jwks = $this->apiRetriever->getJwksAsArray();


### PR DESCRIPTION
Just a quick fix for a simple issue which was discovered by Markus earlier – since I was working on the code I thought I might as well fix it.

```
{
    "message": "Firebase\\JWT\\JWK::parseKeySet(): Argument #1 ($jwks) must be of type array, stdClass given, called in /app/vendor/keeleinstituut/tv-common-laravel-security/src/Services/CachedRealmJwkRetriever.php on line 28",
    "exception": "TypeError",
    "file": "/app/vendor/firebase/php-jwt/src/JWK.php",
    "line": 49,
    "trace": [
        {
            "file": "/app/vendor/keeleinstituut/tv-common-laravel-security/src/Services/CachedRealmJwkRetriever.php",
            "line": 28,
            "function": "parseKeySet",
            "class": "Firebase\\JWT\\JWK",
            "type": "::"
        },
        {
            "file": "/app/vendor/keeleinstituut/tv-common-laravel-security/src/Services/Decoders/JwtTokenDecoder.php",
            "line": 41,
            "function": "getJwkOrJwks",
            "class": "KeycloakAuthGuard\\Services\\CachedRealmJwkRetriever",
            "type": "->"
        },
        ...
    ]
}
```