### PR TITLE
hotfix - improve logic of caching JWKS & pint style fixes

### DIFF
--- a/src/Services/CachedRealmJwkRetriever.php
+++ b/src/Services/CachedRealmJwkRetriever.php
@@ -48,4 +48,9 @@ class CachedRealmJwkRetriever implements RealmJwkRetrieverInterface
     {
         return config('keycloak.realm_public_key_cache_ttl');
     }
+
+    public function cleanupCache(?string $kid = null): void
+    {
+        $this->repository->forget($this->getCacheKey($kid));
+    }
 }

--- a/src/Services/Decoders/JwtTokenDecoder.php
+++ b/src/Services/Decoders/JwtTokenDecoder.php
@@ -5,6 +5,7 @@ namespace KeycloakAuthGuard\Services\Decoders;
 use Exception;
 use KeycloakAuthGuard\Exceptions\InvalidJwtTokenException;
 use KeycloakAuthGuard\JwtToken;
+use KeycloakAuthGuard\Services\CachedRealmJwkRetriever;
 use KeycloakAuthGuard\Services\RealmJwkRetrieverInterface;
 use stdClass;
 
@@ -14,10 +15,13 @@ readonly class JwtTokenDecoder
 
     private string $realm;
 
+    private int $leeway;
+
     public function __construct(private RealmJwkRetrieverInterface $jwkRetriever)
     {
         $this->keycloakBaseUrl = trim(config('keycloak.base_url'), '/');
         $this->realm = config('keycloak.realm');
+        $this->leeway = config('keycloak.leeway');
     }
 
     /**
@@ -35,29 +39,26 @@ readonly class JwtTokenDecoder
     {
         try {
             $kid = JwtToken::getHeader($token)->kid ?? null;
-            $token = JwtToken::decode(
-                $token,
-                $this->jwkRetriever->getJwkOrJwks($kid),
-                config('keycloak.leeway')
-            );
         } catch (Exception $e) {
-            throw new InvalidJwtTokenException('JWT token is invalid', 0, $e);
+            throw new InvalidJwtTokenException("Retrieving of JWT token 'kid' is failed", 0, $e);
         }
 
-        if (empty($token)) {
-            return null;
-        }
+        $decodedToken = $this->getDecodedToken($token, $kid);
 
-        $this->validate($token, $validateAzp, $validateIss);
+        $this->validate($decodedToken, $validateAzp, $validateIss);
 
-        return $token;
+        return $decodedToken;
     }
 
     /**
      * @throws InvalidJwtTokenException
      */
-    private function validate(stdClass $token, bool $validateAzp, bool $validateIss): void
+    private function validate(?stdClass $token, bool $validateAzp, bool $validateIss): void
     {
+        if (empty($token)) {
+            throw new InvalidJwtTokenException('Token decode returned empty result');
+        }
+
         if ($validateAzp) {
             $acceptedAuthorizedParties = explode(',', config('keycloak.accepted_authorized_parties'));
             if (! property_exists($token, 'azp')) {
@@ -83,5 +84,24 @@ readonly class JwtTokenDecoder
     private function getExpectedIssuer(): string
     {
         return "$this->keycloakBaseUrl/realms/$this->realm";
+    }
+
+    private function getDecodedToken(string $token, ?string $kid, bool $cacheRefreshed = false): ?stdClass
+    {
+        try {
+            return JwtToken::decode(
+                $token,
+                $this->jwkRetriever->getJwkOrJwks($kid),
+                $this->leeway
+            );
+        } catch (Exception $e) {
+            if ($this->jwkRetriever instanceof CachedRealmJwkRetriever && ! $cacheRefreshed) {
+                $this->jwkRetriever->cleanupCache($kid);
+
+                return $this->getDecodedToken($token, $kid, true);
+            }
+
+            throw new InvalidJwtTokenException('JWT token is invalid', 0, $e);
+        }
     }
 }

--- a/tests/CachedServiceAccountJwtRetrieverTest.php
+++ b/tests/CachedServiceAccountJwtRetrieverTest.php
@@ -12,7 +12,6 @@ use KeycloakAuthGuard\Services\ConfigRealmJwkRetriever;
 use KeycloakAuthGuard\Services\Decoders\JwtTokenDecoder;
 use KeycloakAuthGuard\Services\ServiceAccountJwtRetriever;
 use Psr\SimpleCache\InvalidArgumentException;
-use RuntimeException;
 
 class CachedServiceAccountJwtRetrieverTest extends TestCase
 {
@@ -35,7 +34,7 @@ class CachedServiceAccountJwtRetrieverTest extends TestCase
      */
     public function test_receiving_and_caching_of_service_account_jwt()
     {
-        Http::fake(fn() => Http::response($this->getServiceAccountObtainJwtResponse()));
+        Http::fake(fn () => Http::response($this->getServiceAccountObtainJwtResponse()));
         $retriever = $this->getJwtRetriever();
         $jwt = $retriever->getJwt();
 
@@ -54,7 +53,7 @@ class CachedServiceAccountJwtRetrieverTest extends TestCase
     public function test_caching_of_service_account_jwt_that_will_expire_soon()
     {
         $cacheExpiryDelay = config('keycloak.service_account_jwt_cache_expiry_delay') - 1;
-        Http::fake(fn() => Http::response($this->getServiceAccountObtainJwtResponse($cacheExpiryDelay)));
+        Http::fake(fn () => Http::response($this->getServiceAccountObtainJwtResponse($cacheExpiryDelay)));
         $this->expectException(TooShortJwtLifetimeException::class);
         $this->getJwtRetriever()->getJwt();
     }
@@ -66,7 +65,7 @@ class CachedServiceAccountJwtRetrieverTest extends TestCase
     public function test_caching_of_service_account_without_exp_claim()
     {
         $this->buildCustomToken([]);
-        Http::fake(fn() => Http::response([
+        Http::fake(fn () => Http::response([
             'access_token' => $this->token,
             'expires_in' => 300,
         ]));


### PR DESCRIPTION
Slack thread: https://pundar.slack.com/archives/C053FD55ATT/p1696342430257459

Improved logic of caching JWKS by cleaning up the corresponding `kid` cache in case decoding failed.